### PR TITLE
Evaluate Elisp formatters

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nurpkgs": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749652694,
+        "narHash": "sha256-t+aUD/ftUkiFouhCM/1H0zYPWVegoCPHhXUdUuFwZvA=",
+        "owner": "cameronyule",
+        "repo": "nurpkgs",
+        "rev": "75e31a760c63692bf2a84efe7a3cd29ea9592cfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cameronyule",
+        "repo": "nurpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nurpkgs": "nurpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-unstable";
+    };
+    nurpkgs = {
+      url = "github:cameronyule/nurpkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nurpkgs,
+    flake-utils,
+    treefmt-nix,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        treefmtEval = treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
+          programs = {
+            # keep-sorted start
+            alejandra.enable = true;
+            keep-sorted.enable = true;
+            mdformat.enable = true;
+            statix.enable = true;
+            # keep-sorted end
+          };
+
+          settings = {
+            allow-missing-formatter = false;
+            on-unmatched = "fatal";
+            verbose = 2;
+            global.excludes = [
+              ".editorconfig"
+            ];
+            formatter = {
+              lisp = {
+                command = "${nurpkgs.packages.${system}.lisp-format}/bin/lisp-format";
+                options = ["-i"];
+                includes = ["*.el"];
+              };
+            };
+          };
+        };
+      in {
+        # For `nix fmt`
+        formatter = treefmtEval.config.build.wrapper;
+
+        checks = {
+          # For `nix flake check`
+          formatting = treefmtEval.config.build.check self;
+        };
+      }
+    );
+}


### PR DESCRIPTION
I don't currently have an auto-formatter defined for Elisp files, which will become more problematic the larger my configuration files become.