### PR TITLE
Enable tty module

### DIFF
--- a/init.el
+++ b/init.el
@@ -53,7 +53,7 @@
 
   :os
   (:if (featurep :system 'macos) macos)
-  ;;tty
+  tty
 
   :lang
   emacs-lisp


### PR DESCRIPTION
Even though I mostly use Emacs as a native graphical application, I also use it in the terminal when needed.

Doom has an optional [tty module](https://github.com/doomemacs/doomemacs/tree/master/modules/os/tty) which aims to improve the terminal experience, with better [keyboard](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), [mouse](https://www.gnu.org/software/emacs/manual/html_node/emacs/Text_002dOnly-Mouse.html), and clipboard support.