### PR TITLE
Indent guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist/
 
 # Dependency directories
 node_modules/
+.aider*

--- a/init.el
+++ b/init.el
@@ -16,6 +16,7 @@
   doom
   doom-dashboard
   hl-todo
+  indent-guides
   modeline
   ophints
   (popup +defaults)


### PR DESCRIPTION
Doom has built-in support for displaying [indent-bars](https://github.com/jdtsmith/indent-bars) in the [ui/indent-guides](https://github.com/doomemacs/doomemacs/tree/master/modules/ui/indent-guides) module but it's off by default.

After enabling this be sure it doesn't further negatively impact performance, which is being tracked in #18.